### PR TITLE
feat: Add CIDR notation support for IP filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,6 +1169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "iri-string"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1796,7 @@ dependencies = [
  "dashmap",
  "env_logger",
  "http",
+ "ipnetwork",
  "log",
  "once_cell",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ dashmap = "6.1"
 parking_lot = "0.12"
 urlencoding = "2.1"
 clap = { version = "4.5", features = ["derive"] }
+ipnetwork = "0.20"
 
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A high-performance, memory-safe Web Application Firewall built with Cloudflare's
 - ✅ **SQL Injection Detection** - Advanced pattern matching with 15+ attack signatures, 100% detection rate
 - ✅ **XSS Prevention** - Cross-site scripting attack blocking with URL decoding
 - ✅ **Rate Limiting** - Per-IP request throttling with configurable windows
-- ✅ **IP Filtering** - Whitelist/blacklist support for network-level protection
+- ✅ **IP Filtering** - Whitelist/blacklist with CIDR notation support (e.g., `10.0.0.0/8`)
 - ✅ **Request Body Inspection** - Deep packet analysis with configurable size limits (1MB default)
 - ✅ **Header Validation** - Custom header security checks with safe header exemptions
 
@@ -176,11 +176,16 @@ rate_limit:
   max_requests: 1000    # Maximum requests per window
   window_secs: 60       # Time window in seconds (1000/min = ~17 req/sec per IP)
 
-# IP Address Filtering
+# IP Address Filtering (with CIDR support)
 ip_filter:
   enabled: false        # Enable for production
-  whitelist: []         # Allow only these IPs (empty = allow all)
-  blacklist: []         # Block these IPs
+  whitelist: []         # Allow only these IPs/networks (empty = allow all)
+  blacklist: []         # Block these IPs/networks
+  # Supports both individual IPs and CIDR notation:
+  # - "192.168.1.1"      → Single IP (treated as /32)
+  # - "10.0.0.0/8"       → CIDR range (10.0.0.0 - 10.255.255.255)
+  # - "192.168.0.0/16"   → CIDR range (192.168.0.0 - 192.168.255.255)
+  # - "2001:db8::/32"    → IPv6 CIDR range
 
 # Request Body Limits
 max_body_size: 1048576  # 1MB in bytes

--- a/config/waf_rules.yaml
+++ b/config/waf_rules.yaml
@@ -15,7 +15,9 @@ ip_filter:
   enabled: true
   whitelist: []
   blacklist:
-    - "192.168.1.100"
-    - "10.0.0.50"
+    - "192.168.1.100"      # Single IP
+    - "10.0.0.0/8"         # CIDR range - blocks entire 10.x.x.x network
+    - "198.51.100.0/24"    # CIDR range - blocks 198.51.100.0-255
 
 max_body_size: 1048576 # 1MB in bytes
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -530,20 +530,30 @@ ip_filter:
 
 ### Common IP Ranges
 
-#### Private Networks (RFC 1918)
+#### Private Networks (RFC 1918 - IPv4)
 
 ```
 whitelist:
-  - "10.0.0.0/8"          # Class A private
-  - "172.16.0.0/12"       # Class B private
-  - "192.168.0.0/16"      # Class C private
+  - "10.0.0.0/8"          # Class A private (16M hosts)
+  - "172.16.0.0/12"       # Class B private (1M hosts)
+  - "192.168.0.0/16"      # Class C private (65K hosts)
+```
+
+#### IPv6 Networks
+
+```
+whitelist:
+  - "fc00::/7"            # Unique Local Addresses (ULA)
+  - "fe80::/10"           # Link-Local Addresses
+  - "2001:db8::/32"       # Documentation prefix
 ```
 
 #### Localhost
 
 ```
 whitelist:
-  - "127.0.0.1"           # IPv4 localhost
+  - "127.0.0.1"           # IPv4 localhost (single IP)
+  - "127.0.0.0/8"         # IPv4 loopback range (CIDR)
   - "::1"                 # IPv6 localhost
 ```
 

--- a/src/waf/ip_filter.rs
+++ b/src/waf/ip_filter.rs
@@ -1,35 +1,92 @@
-use std::collections::HashSet;
+use ipnetwork::IpNetwork;
 use std::net::IpAddr;
 use std::str::FromStr;
+
 use super::{SecurityViolation, ThreatLevel};
 
+/// IP Filter with CIDR notation support
+///
+/// Supports both individual IPs and CIDR ranges:
+/// - Individual IP: "192.168.1.1" (treated as /32 for IPv4, /128 for IPv6)
+/// - CIDR range: "192.168.1.0/24", "10.0.0.0/8", "2001:db8::/32"
 pub struct IpFilter {
-    pub whitelist: HashSet<IpAddr>,
-    pub blacklist: HashSet<IpAddr>,
+    /// Networks in the whitelist (only these IPs allowed if non-empty)
+    pub whitelist: Vec<IpNetwork>,
+    /// Networks in the blacklist (these IPs are blocked)
+    pub blacklist: Vec<IpNetwork>,
+    /// Whether IP filtering is enabled
     pub enabled: bool,
 }
 
 impl IpFilter {
+    /// Create a new IP filter
     pub fn new(enabled: bool) -> Self {
         Self {
-            whitelist: HashSet::new(),
-            blacklist: HashSet::new(),
+            whitelist: Vec::new(),
+            blacklist: Vec::new(),
             enabled,
         }
     }
 
-    pub fn add_to_whitelist(&mut self, ip: &str) -> Result<(), String> {
-        let addr = IpAddr::from_str(ip).map_err(|e| e.to_string())?;
-        self.whitelist.insert(addr);
+    /// Add an IP or CIDR range to the whitelist
+    ///
+    /// # Examples
+    /// ```
+    /// filter.add_to_whitelist("192.168.1.1");      // Single IP
+    /// filter.add_to_whitelist("10.0.0.0/8");       // CIDR range
+    /// filter.add_to_whitelist("2001:db8::/32");    // IPv6 CIDR
+    /// ```
+    pub fn add_to_whitelist(&mut self, ip_or_cidr: &str) -> Result<(), String> {
+        let network = self.parse_ip_or_cidr(ip_or_cidr)?;
+        self.whitelist.push(network);
         Ok(())
     }
 
-    pub fn add_to_blacklist(&mut self, ip: &str) -> Result<(), String> {
-        let addr = IpAddr::from_str(ip).map_err(|e| e.to_string())?;
-        self.blacklist.insert(addr);
+    /// Add an IP or CIDR range to the blacklist
+    ///
+    /// # Examples
+    /// ```
+    /// filter.add_to_blacklist("192.168.1.100");    // Single IP
+    /// filter.add_to_blacklist("198.51.100.0/24");  // CIDR range
+    /// ```
+    pub fn add_to_blacklist(&mut self, ip_or_cidr: &str) -> Result<(), String> {
+        let network = self.parse_ip_or_cidr(ip_or_cidr)?;
+        self.blacklist.push(network);
         Ok(())
     }
 
+    /// Parse an IP address or CIDR notation string into an IpNetwork
+    ///
+    /// Supports:
+    /// - "192.168.1.1" -> 192.168.1.1/32
+    /// - "192.168.1.0/24" -> 192.168.1.0/24
+    /// - "::1" -> ::1/128
+    /// - "2001:db8::/32" -> 2001:db8::/32
+    fn parse_ip_or_cidr(&self, input: &str) -> Result<IpNetwork, String> {
+        // First try to parse as CIDR notation
+        if let Ok(network) = IpNetwork::from_str(input) {
+            return Ok(network);
+        }
+
+        // If that fails, try to parse as a single IP and convert to /32 or /128
+        if let Ok(ip) = IpAddr::from_str(input) {
+            match ip {
+                IpAddr::V4(v4) => IpNetwork::new(IpAddr::V4(v4), 32).map_err(|e| e.to_string()),
+                IpAddr::V6(v6) => IpNetwork::new(IpAddr::V6(v6), 128).map_err(|e| e.to_string()),
+            }
+        } else {
+            Err(format!("Invalid IP address or CIDR notation: {}", input))
+        }
+    }
+
+    /// Check if an IP address is in the given network list
+    fn ip_in_networks(&self, ip: &IpAddr, networks: &[IpNetwork]) -> bool {
+        networks.iter().any(|network| network.contains(*ip))
+    }
+
+    /// Check if an IP address passes the filter
+    ///
+    /// Returns Ok(()) if the IP is allowed, Err(SecurityViolation) if blocked
     pub fn check_ip(&self, ip_str: &str) -> Result<(), SecurityViolation> {
         if !self.enabled {
             return Ok(());
@@ -37,11 +94,11 @@ impl IpFilter {
 
         let ip = match IpAddr::from_str(ip_str) {
             Ok(addr) => addr,
-            Err(_) => return Ok(()),
+            Err(_) => return Ok(()), // Invalid IP format, let it through
         };
 
-        // Check whitelist first
-        if !self.whitelist.is_empty() && !self.whitelist.contains(&ip) {
+        // Check whitelist first - if whitelist is non-empty, IP must be in it
+        if !self.whitelist.is_empty() && !self.ip_in_networks(&ip, &self.whitelist) {
             return Err(SecurityViolation {
                 threat_type: "IP_NOT_WHITELISTED".to_string(),
                 threat_level: ThreatLevel::High,
@@ -50,8 +107,8 @@ impl IpFilter {
             });
         }
 
-        // Check blacklist
-        if self.blacklist.contains(&ip) {
+        // Check blacklist - if IP is in any blacklisted network, block it
+        if self.ip_in_networks(&ip, &self.blacklist) {
             return Err(SecurityViolation {
                 threat_type: "IP_BLACKLISTED".to_string(),
                 threat_level: ThreatLevel::Critical,
@@ -61,5 +118,108 @@ impl IpFilter {
         }
 
         Ok(())
+    }
+
+    /// Get the number of whitelist entries
+    pub fn whitelist_count(&self) -> usize {
+        self.whitelist.len()
+    }
+
+    /// Get the number of blacklist entries  
+    pub fn blacklist_count(&self) -> usize {
+        self.blacklist.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_ip_whitelist() {
+        let mut filter = IpFilter::new(true);
+        filter.add_to_whitelist("192.168.1.1").unwrap();
+
+        assert!(filter.check_ip("192.168.1.1").is_ok());
+        assert!(filter.check_ip("192.168.1.2").is_err());
+    }
+
+    #[test]
+    fn test_cidr_whitelist() {
+        let mut filter = IpFilter::new(true);
+        filter.add_to_whitelist("192.168.1.0/24").unwrap();
+
+        // IPs in range should be allowed
+        assert!(filter.check_ip("192.168.1.1").is_ok());
+        assert!(filter.check_ip("192.168.1.100").is_ok());
+        assert!(filter.check_ip("192.168.1.255").is_ok());
+
+        // IPs outside range should be blocked
+        assert!(filter.check_ip("192.168.2.1").is_err());
+        assert!(filter.check_ip("10.0.0.1").is_err());
+    }
+
+    #[test]
+    fn test_cidr_blacklist() {
+        let mut filter = IpFilter::new(true);
+        filter.add_to_blacklist("10.0.0.0/8").unwrap();
+
+        // IPs in blacklisted range should be blocked
+        assert!(filter.check_ip("10.0.0.1").is_err());
+        assert!(filter.check_ip("10.255.255.255").is_err());
+
+        // IPs outside range should be allowed
+        assert!(filter.check_ip("192.168.1.1").is_ok());
+    }
+
+    #[test]
+    fn test_single_ip_blacklist() {
+        let mut filter = IpFilter::new(true);
+        filter.add_to_blacklist("192.168.1.100").unwrap();
+
+        assert!(filter.check_ip("192.168.1.100").is_err());
+        assert!(filter.check_ip("192.168.1.101").is_ok());
+    }
+
+    #[test]
+    fn test_disabled_filter() {
+        let mut filter = IpFilter::new(false);
+        filter.add_to_blacklist("0.0.0.0/0").unwrap(); // Block everything
+
+        // Should still allow because filter is disabled
+        assert!(filter.check_ip("192.168.1.1").is_ok());
+    }
+
+    #[test]
+    fn test_ipv6_cidr() {
+        let mut filter = IpFilter::new(true);
+        filter.add_to_whitelist("2001:db8::/32").unwrap();
+
+        assert!(filter.check_ip("2001:db8::1").is_ok());
+        assert!(filter.check_ip("2001:db9::1").is_err());
+    }
+
+    #[test]
+    fn test_mixed_whitelist_blacklist() {
+        let mut filter = IpFilter::new(true);
+        filter.add_to_whitelist("192.168.0.0/16").unwrap();
+        filter.add_to_blacklist("192.168.1.100").unwrap();
+
+        // In whitelist but also in blacklist - blacklist wins
+        assert!(filter.check_ip("192.168.1.100").is_err());
+
+        // In whitelist, not in blacklist - allowed
+        assert!(filter.check_ip("192.168.1.1").is_ok());
+
+        // Not in whitelist - blocked
+        assert!(filter.check_ip("10.0.0.1").is_err());
+    }
+
+    #[test]
+    fn test_invalid_cidr() {
+        let mut filter = IpFilter::new(true);
+
+        assert!(filter.add_to_whitelist("invalid").is_err());
+        assert!(filter.add_to_whitelist("192.168.1.0/33").is_err());
     }
 }


### PR DESCRIPTION
- Add ipnetwork crate for CIDR parsing and matching
- Rewrite IpFilter to use Vec<IpNetwork> instead of HashSet<IpAddr>
- Support both individual IPs and CIDR ranges (e.g., 10.0.0.0/8)
- Add IPv6 CIDR support (e.g., 2001:db8::/32)
- Add 8 unit tests for CIDR functionality
- Update documentation:
  - README.md: feature highlight and config examples
  - docs/api-reference.md: IpFilter API with new methods
  - docs/security-rules.md: IPv4/IPv6 CIDR examples
  - docs/configuration.md: IPv6 network ranges
- Update waf_rules.yaml with CIDR examples