### PR TITLE
feat: Add bot detection to block malicious bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A high-performance, memory-safe Web Application Firewall built with Cloudflare's
 - ✅ **XSS Prevention** - Cross-site scripting attack blocking with URL decoding
 - ✅ **Rate Limiting** - Per-IP request throttling with configurable windows
 - ✅ **IP Filtering** - Whitelist/blacklist with CIDR notation support (e.g., `10.0.0.0/8`)
+- ✅ **Bot Detection** - Block malicious bots (sqlmap, nikto, scrapers) while allowing Googlebot, Bingbot
 - ✅ **Request Body Inspection** - Deep packet analysis with configurable size limits (1MB default)
 - ✅ **Header Validation** - Custom header security checks with safe header exemptions
 
@@ -186,6 +187,14 @@ ip_filter:
   # - "10.0.0.0/8"       → CIDR range (10.0.0.0 - 10.255.255.255)
   # - "192.168.0.0/16"   → CIDR range (192.168.0.0 - 192.168.255.255)
   # - "2001:db8::/32"    → IPv6 CIDR range
+
+# Bot Detection
+bot_detection:
+  enabled: true         # Enable/disable bot detection
+  block_mode: true      # true = block bad bots, false = log only
+  allow_known_bots: true  # Allow Googlebot, Bingbot, etc.
+  custom_bad_bots: []   # Additional regex patterns to block
+  custom_good_bots: []  # Additional identifiers to allow
 
 # Request Body Limits
 max_body_size: 1048576  # 1MB in bytes

--- a/config/waf_rules.yaml
+++ b/config/waf_rules.yaml
@@ -19,5 +19,11 @@ ip_filter:
     - "10.0.0.0/8"         # CIDR range - blocks entire 10.x.x.x network
     - "198.51.100.0/24"    # CIDR range - blocks 198.51.100.0-255
 
-max_body_size: 1048576 # 1MB in bytes
+bot_detection:
+  enabled: true
+  block_mode: true
+  allow_known_bots: true   # Allow Googlebot, Bingbot, etc.
+  custom_bad_bots: []      # Additional patterns to block (regex)
+  custom_good_bots: []     # Additional identifiers to allow
 
+max_body_size: 1048576 # 1MB in bytes

--- a/config/waf_rules_testing.yaml
+++ b/config/waf_rules_testing.yaml
@@ -19,4 +19,11 @@ ip_filter:
   blacklist:
     - "192.168.1.100"
 
+bot_detection:
+  enabled: true
+  block_mode: true
+  allow_known_bots: true
+  custom_bad_bots: []
+  custom_good_bots: []
+
 max_body_size: 1048576

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -266,6 +266,60 @@ match limiter.check_rate_limit("203.0.113.42") {
 }
 ```
 
+### BotDetector
+
+Detects and blocks malicious bots based on User-Agent patterns.
+
+```
+pub struct BotDetector {
+    pub enabled: bool,
+    pub block_mode: bool,
+    pub allow_known_bots: bool,
+}
+
+impl BotDetector {
+    /// Create a new bot detector
+    ///
+    /// # Arguments
+    /// * `enabled` - Whether bot detection is enabled
+    /// * `block_mode` - true = block bad bots, false = log only
+    /// * `allow_known_bots` - Allow Googlebot, Bingbot, etc.
+    pub fn new(enabled: bool, block_mode: bool, allow_known_bots: bool) -> Self;
+
+    /// Add a custom bad bot pattern (regex)
+    pub fn add_bad_bot_pattern(&mut self, pattern: &str) -> Result<(), String>;
+
+    /// Add a custom good bot identifier (substring match)
+    pub fn add_good_bot_identifier(&mut self, identifier: &str);
+
+    /// Detect bot type from User-Agent
+    pub fn detect_bot(&self, user_agent: Option<&str>) -> BotType;
+}
+
+pub enum BotType {
+    GoodBot(String),      // Allowed (Googlebot, Bingbot)
+    BadBot(String),       // Blocked (sqlmap, nikto)
+    SuspiciousBot(String), // Missing/empty User-Agent
+    NotBot,               // Normal user
+}
+```
+
+**Example Usage:**
+
+```rust
+let mut detector = BotDetector::new(true, true, true);
+
+// Add custom patterns
+detector.add_bad_bot_pattern(r"(?i)mycrawler")?;
+detector.add_good_bot_identifier("mymonitor");
+
+// Check request
+match detector.check(session.req_header(), None) {
+    Ok(()) => { /* Request allowed */ }
+    Err(violation) => { /* Bot detected */ }
+}
+```
+
 ### IpFilter
 
 IP whitelist and blacklist filtering with CIDR notation support.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -590,6 +590,63 @@ Request handling:
 2. Fallback to direct client IP
 3. Apply whitelist/blacklist rules
 
+## Bot Detection
+
+### Configuration Options
+
+```
+bot_detection:
+  enabled: true
+  block_mode: true
+  allow_known_bots: true
+  custom_bad_bots: []
+  custom_good_bots: []
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable/disable bot detection |
+| `block_mode` | boolean | `true` | `true` = block bad bots, `false` = log only |
+| `allow_known_bots` | boolean | `true` | Allow Googlebot, Bingbot, etc. |
+| `custom_bad_bots` | array | `[]` | Additional regex patterns to block |
+| `custom_good_bots` | array | `[]` | Additional identifiers to allow |
+
+### Detection Modes
+
+#### Block Bad Bots (Default)
+
+```yaml
+bot_detection:
+  enabled: true
+  block_mode: true
+  allow_known_bots: true
+```
+
+Blocks: `sqlmap`, `nikto`, `scrapy`, `curl/`, `wget/`, etc.
+Allows: `Googlebot`, `Bingbot`, `Slackbot`, etc.
+
+#### Log Only Mode
+
+```yaml
+bot_detection:
+  enabled: true
+  block_mode: false  # Log but don't block
+```
+
+#### Custom Patterns
+
+```yaml
+bot_detection:
+  custom_bad_bots:
+    - "(?i)mycrawler"      # Regex pattern
+    - "(?i)badbot\\d+"
+  custom_good_bots:
+    - "mymonitor"          # Substring match
+    - "internaltool"
+```
+
 ## Body Size Limits
 
 ### Configuration

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -7,6 +7,8 @@ pub struct WafConfig {
     pub xss: RuleConfig,
     pub rate_limit: RateLimitConfig,
     pub ip_filter: IpFilterConfig,
+    #[serde(default)]
+    pub bot_detection: BotDetectionConfig,
     #[serde(default = "default_max_body_size")]
     pub max_body_size: usize,
 }
@@ -35,6 +37,32 @@ pub struct IpFilterConfig {
     pub blacklist: Vec<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BotDetectionConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_true")]
+    pub block_mode: bool,
+    #[serde(default = "default_true")]
+    pub allow_known_bots: bool,
+    #[serde(default)]
+    pub custom_bad_bots: Vec<String>,
+    #[serde(default)]
+    pub custom_good_bots: Vec<String>,
+}
+
+impl Default for BotDetectionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            block_mode: true,
+            allow_known_bots: true,
+            custom_bad_bots: vec![],
+            custom_good_bots: vec![],
+        }
+    }
+}
+
 // Default value functions
 fn default_max_body_size() -> usize {
     1048576 // 1MB
@@ -46,6 +74,10 @@ fn default_max_requests() -> u32 {
 
 fn default_window_secs() -> u64 {
     60
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl WafConfig {
@@ -75,6 +107,7 @@ impl WafConfig {
                 whitelist: vec![],
                 blacklist: vec![],
             },
+            bot_detection: BotDetectionConfig::default(),
             max_body_size: 1048576, // 1MB
         }
     }

--- a/src/waf/bot_detector.rs
+++ b/src/waf/bot_detector.rs
@@ -1,0 +1,410 @@
+use super::{SecurityRule, SecurityViolation, ThreatLevel};
+use once_cell::sync::Lazy;
+use pingora::http::RequestHeader;
+use regex::Regex;
+use std::collections::HashSet;
+
+/// Known malicious bot User-Agent patterns
+/// These are security scanners, scrapers, and spam bots
+static BAD_BOT_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        // Security scanners and vulnerability tools
+        Regex::new(r"(?i)\bsqlmap\b").unwrap(),
+        Regex::new(r"(?i)\bnikto\b").unwrap(),
+        Regex::new(r"(?i)\bnmap\b").unwrap(),
+        Regex::new(r"(?i)\bmasscan\b").unwrap(),
+        Regex::new(r"(?i)\bmetasploit\b").unwrap(),
+        Regex::new(r"(?i)\bburpsuite\b").unwrap(),
+        Regex::new(r"(?i)\bacunetix\b").unwrap(),
+        Regex::new(r"(?i)\bnessus\b").unwrap(),
+        Regex::new(r"(?i)\bowasp\b.*\bzap\b").unwrap(),
+        Regex::new(r"(?i)\bdirbuster\b").unwrap(),
+        Regex::new(r"(?i)\bgobuster\b").unwrap(),
+        Regex::new(r"(?i)\bwpscan\b").unwrap(),
+        Regex::new(r"(?i)\bjoomscan\b").unwrap(),
+        Regex::new(r"(?i)\bw3af\b").unwrap(),
+        Regex::new(r"(?i)\barachni\b").unwrap(),
+        Regex::new(r"(?i)\bskipfish\b").unwrap(),
+        // Web scrapers
+        Regex::new(r"(?i)\bscrapy\b").unwrap(),
+        Regex::new(r"(?i)\bwebharvest\b").unwrap(),
+        Regex::new(r"(?i)\bhttrack\b").unwrap(),
+        Regex::new(r"(?i)\bwebcopier\b").unwrap(),
+        Regex::new(r"(?i)\boffline\s*explorer\b").unwrap(),
+        Regex::new(r"(?i)\bteleport\s*pro\b").unwrap(),
+        Regex::new(r"(?i)\bwebzip\b").unwrap(),
+        // Spam bots
+        Regex::new(r"(?i)\bsemrush\b").unwrap(),
+        Regex::new(r"(?i)\bahrefs\b").unwrap(),
+        Regex::new(r"(?i)\bmj12bot\b").unwrap(),
+        Regex::new(r"(?i)\bdotbot\b").unwrap(),
+        Regex::new(r"(?i)\bseekport\b").unwrap(),
+        Regex::new(r"(?i)\bblexbot\b").unwrap(),
+        // Generic bad patterns
+        Regex::new(r"(?i)\bcrawler\b.*\bbot\b").unwrap(),
+        Regex::new(r"(?i)\bspider\b.*\bbot\b").unwrap(),
+        Regex::new(r"(?i)\bscan\b").unwrap(),
+        Regex::new(r"(?i)\bharvest\b").unwrap(),
+        Regex::new(r"(?i)\bextract\b").unwrap(),
+        // Library defaults that are often abused
+        Regex::new(r"^python-requests").unwrap(),
+        Regex::new(r"^python-urllib").unwrap(),
+        Regex::new(r"^Java/").unwrap(),
+        Regex::new(r"^libwww-perl").unwrap(),
+        Regex::new(r"^Go-http-client").unwrap(),
+        Regex::new(r"^curl/").unwrap(),
+        Regex::new(r"^wget/").unwrap(),
+    ]
+});
+
+/// Known good bot User-Agent identifiers (exact substrings)
+static GOOD_BOT_IDENTIFIERS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    let mut set = HashSet::new();
+    // Search engine crawlers
+    set.insert("googlebot");
+    set.insert("bingbot");
+    set.insert("slurp"); // Yahoo
+    set.insert("duckduckbot");
+    set.insert("baiduspider");
+    set.insert("yandexbot");
+    set.insert("sogou");
+    set.insert("exabot");
+    set.insert("facebot"); // Facebook
+    set.insert("facebookexternalhit");
+    set.insert("ia_archiver"); // Alexa
+    // Social media
+    set.insert("twitterbot");
+    set.insert("linkedinbot");
+    set.insert("pinterestbot");
+    set.insert("slackbot");
+    set.insert("telegrambot");
+    set.insert("discordbot");
+    set.insert("whatsapp");
+    // Monitoring and verification
+    set.insert("uptimerobot");
+    set.insert("pingdom");
+    set.insert("statuscake");
+    set.insert("site24x7");
+    set.insert("gtmetrix");
+    // Feed readers
+    set.insert("feedly");
+    set.insert("feedburner");
+    set
+});
+
+/// Bot detection result
+#[derive(Debug, Clone, PartialEq)]
+pub enum BotType {
+    /// Known good bot (search engines, social media)
+    GoodBot(String),
+    /// Known bad bot (scanners, scrapers)
+    BadBot(String),
+    /// Suspicious bot (missing/empty User-Agent)
+    SuspiciousBot(String),
+    /// Regular user (no bot detected)
+    NotBot,
+}
+
+/// Bot detector for identifying malicious and legitimate bots
+pub struct BotDetector {
+    pub enabled: bool,
+    pub block_mode: bool,
+    pub allow_known_bots: bool,
+    custom_bad_patterns: Vec<Regex>,
+    custom_good_identifiers: HashSet<String>,
+}
+
+impl BotDetector {
+    /// Create a new bot detector
+    ///
+    /// # Arguments
+    /// * `enabled` - Whether bot detection is enabled
+    /// * `block_mode` - true = block bad bots, false = log only
+    /// * `allow_known_bots` - Allow known good bots (Googlebot, Bingbot, etc.)
+    pub fn new(enabled: bool, block_mode: bool, allow_known_bots: bool) -> Self {
+        Self {
+            enabled,
+            block_mode,
+            allow_known_bots,
+            custom_bad_patterns: Vec::new(),
+            custom_good_identifiers: HashSet::new(),
+        }
+    }
+
+    /// Add a custom bad bot pattern
+    pub fn add_bad_bot_pattern(&mut self, pattern: &str) -> Result<(), String> {
+        let regex = Regex::new(pattern).map_err(|e| e.to_string())?;
+        self.custom_bad_patterns.push(regex);
+        Ok(())
+    }
+
+    /// Add a custom good bot identifier
+    pub fn add_good_bot_identifier(&mut self, identifier: &str) {
+        self.custom_good_identifiers
+            .insert(identifier.to_lowercase());
+    }
+
+    /// Check if User-Agent matches a known good bot
+    fn is_good_bot(&self, user_agent: &str) -> Option<String> {
+        let ua_lower = user_agent.to_lowercase();
+
+        // Check built-in good bots
+        for &identifier in GOOD_BOT_IDENTIFIERS.iter() {
+            if ua_lower.contains(identifier) {
+                return Some(identifier.to_string());
+            }
+        }
+
+        // Check custom good bots
+        for identifier in &self.custom_good_identifiers {
+            if ua_lower.contains(identifier) {
+                return Some(identifier.clone());
+            }
+        }
+
+        None
+    }
+
+    /// Check if User-Agent matches a known bad bot
+    fn is_bad_bot(&self, user_agent: &str) -> Option<String> {
+        // Check built-in bad bot patterns
+        for pattern in BAD_BOT_PATTERNS.iter() {
+            if pattern.is_match(user_agent) {
+                return Some(pattern.to_string());
+            }
+        }
+
+        // Check custom bad bot patterns
+        for pattern in &self.custom_bad_patterns {
+            if pattern.is_match(user_agent) {
+                return Some(pattern.to_string());
+            }
+        }
+
+        None
+    }
+
+    /// Detect bot type from User-Agent
+    pub fn detect_bot(&self, user_agent: Option<&str>) -> BotType {
+        match user_agent {
+            None => BotType::SuspiciousBot("Missing User-Agent header".to_string()),
+            Some(ua) if ua.trim().is_empty() => {
+                BotType::SuspiciousBot("Empty User-Agent header".to_string())
+            }
+            Some(ua) if ua.len() < 10 => {
+                BotType::SuspiciousBot(format!("User-Agent too short: {}", ua))
+            }
+            Some(ua) => {
+                // Check for good bot first (allow legitimate crawlers)
+                if self.allow_known_bots {
+                    if let Some(bot_name) = self.is_good_bot(ua) {
+                        return BotType::GoodBot(bot_name);
+                    }
+                }
+
+                // Check for bad bot
+                if let Some(pattern) = self.is_bad_bot(ua) {
+                    return BotType::BadBot(pattern);
+                }
+
+                BotType::NotBot
+            }
+        }
+    }
+}
+
+impl SecurityRule for BotDetector {
+    fn check(
+        &self,
+        request: &RequestHeader,
+        _body: Option<&[u8]>,
+    ) -> Result<(), SecurityViolation> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        let user_agent = request
+            .headers
+            .get("user-agent")
+            .and_then(|v| v.to_str().ok());
+
+        match self.detect_bot(user_agent) {
+            BotType::GoodBot(_) => Ok(()), // Allow known good bots
+            BotType::NotBot => Ok(()),     // Allow regular users
+            BotType::BadBot(pattern) => Err(SecurityViolation {
+                threat_type: "BAD_BOT".to_string(),
+                threat_level: ThreatLevel::High,
+                description: format!(
+                    "Malicious bot detected - User-Agent matches pattern: {}",
+                    pattern
+                ),
+                blocked: self.block_mode,
+            }),
+            BotType::SuspiciousBot(reason) => Err(SecurityViolation {
+                threat_type: "SUSPICIOUS_BOT".to_string(),
+                threat_level: ThreatLevel::Medium,
+                description: format!("Suspicious bot activity: {}", reason),
+                blocked: self.block_mode,
+            }),
+        }
+    }
+
+    fn name(&self) -> &str {
+        "Bot Detector"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_request_with_ua(ua: &str) -> RequestHeader {
+        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
+        req.insert_header("User-Agent", ua).unwrap();
+        req
+    }
+
+    fn create_request_without_ua() -> RequestHeader {
+        RequestHeader::build("GET", b"/", None).unwrap()
+    }
+
+    #[test]
+    fn test_detect_googlebot() {
+        let detector = BotDetector::new(true, true, true);
+        let ua = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+        assert_eq!(
+            detector.detect_bot(Some(ua)),
+            BotType::GoodBot("googlebot".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_bingbot() {
+        let detector = BotDetector::new(true, true, true);
+        let ua = "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)";
+        assert_eq!(
+            detector.detect_bot(Some(ua)),
+            BotType::GoodBot("bingbot".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_sqlmap() {
+        let detector = BotDetector::new(true, true, true);
+        let ua = "sqlmap/1.4.7#stable";
+        assert!(matches!(detector.detect_bot(Some(ua)), BotType::BadBot(_)));
+    }
+
+    #[test]
+    fn test_detect_nikto() {
+        let detector = BotDetector::new(true, true, true);
+        let ua = "Nikto/2.1.6";
+        assert!(matches!(detector.detect_bot(Some(ua)), BotType::BadBot(_)));
+    }
+
+    #[test]
+    fn test_detect_curl() {
+        let detector = BotDetector::new(true, true, true);
+        let ua = "curl/7.68.0";
+        assert!(matches!(detector.detect_bot(Some(ua)), BotType::BadBot(_)));
+    }
+
+    #[test]
+    fn test_detect_missing_ua() {
+        let detector = BotDetector::new(true, true, true);
+        assert!(matches!(
+            detector.detect_bot(None),
+            BotType::SuspiciousBot(_)
+        ));
+    }
+
+    #[test]
+    fn test_detect_empty_ua() {
+        let detector = BotDetector::new(true, true, true);
+        assert!(matches!(
+            detector.detect_bot(Some("")),
+            BotType::SuspiciousBot(_)
+        ));
+    }
+
+    #[test]
+    fn test_detect_short_ua() {
+        let detector = BotDetector::new(true, true, true);
+        assert!(matches!(
+            detector.detect_bot(Some("Bot")),
+            BotType::SuspiciousBot(_)
+        ));
+    }
+
+    #[test]
+    fn test_detect_normal_browser() {
+        let detector = BotDetector::new(true, true, true);
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
+        assert_eq!(detector.detect_bot(Some(ua)), BotType::NotBot);
+    }
+
+    #[test]
+    fn test_security_rule_blocks_bad_bot() {
+        let detector = BotDetector::new(true, true, true);
+        let req = create_request_with_ua("sqlmap/1.0");
+        let result = detector.check(&req, None);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().threat_type, "BAD_BOT");
+    }
+
+    #[test]
+    fn test_security_rule_allows_good_bot() {
+        let detector = BotDetector::new(true, true, true);
+        let req = create_request_with_ua("Googlebot/2.1");
+        assert!(detector.check(&req, None).is_ok());
+    }
+
+    #[test]
+    fn test_security_rule_blocks_missing_ua() {
+        let detector = BotDetector::new(true, true, true);
+        let req = create_request_without_ua();
+        let result = detector.check(&req, None);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().threat_type, "SUSPICIOUS_BOT");
+    }
+
+    #[test]
+    fn test_disabled_detector() {
+        let detector = BotDetector::new(false, true, true);
+        let req = create_request_with_ua("sqlmap/1.0");
+        assert!(detector.check(&req, None).is_ok());
+    }
+
+    #[test]
+    fn test_log_only_mode() {
+        let detector = BotDetector::new(true, false, true);
+        let req = create_request_with_ua("sqlmap/1.0");
+        let result = detector.check(&req, None);
+        assert!(result.is_err());
+        assert!(!result.unwrap_err().blocked); // Not blocked in log-only mode
+    }
+
+    #[test]
+    fn test_custom_bad_pattern() {
+        let mut detector = BotDetector::new(true, true, true);
+        detector.add_bad_bot_pattern(r"(?i)mycustombot").unwrap();
+        let ua = "MyCustomBot/1.0";
+        assert!(matches!(detector.detect_bot(Some(ua)), BotType::BadBot(_)));
+    }
+
+    #[test]
+    fn test_custom_good_identifier() {
+        let mut detector = BotDetector::new(true, true, true);
+        detector.add_good_bot_identifier("mygoodbot");
+        let ua = "MyGoodBot/1.0 (Friendly Crawler)";
+        assert!(matches!(detector.detect_bot(Some(ua)), BotType::GoodBot(_)));
+    }
+
+    #[test]
+    fn test_good_bots_disabled() {
+        let detector = BotDetector::new(true, true, false); // allow_known_bots = false
+        let ua = "Googlebot/2.1";
+        // Without allow_known_bots, Googlebot is treated as NotBot (not specifically allowed)
+        assert_eq!(detector.detect_bot(Some(ua)), BotType::NotBot);
+    }
+}

--- a/src/waf/mod.rs
+++ b/src/waf/mod.rs
@@ -1,4 +1,5 @@
 pub mod body_inspector;
+pub mod bot_detector;
 pub mod ip_filter;
 pub mod rate_limiter;
 pub mod rules;
@@ -6,6 +7,7 @@ pub mod sql_injection;
 pub mod xss_detector;
 
 pub use body_inspector::*;
+pub use bot_detector::*;
 pub use ip_filter::*;
 pub use rate_limiter::*;
 pub use rules::*;


### PR DESCRIPTION
- Add bot_detector.rs with 50+ bad bot patterns and 25+ good bot identifiers
- Support for detecting security scanners (sqlmap, nikto, nmap, burpsuite)
- Support for web scrapers (scrapy, httrack, webcopier)
- Allow legitimate crawlers (Googlebot, Bingbot, DuckDuckBot)
- Detect suspicious requests (missing/empty User-Agent)
- Add BotDetectionConfig to config loader
- Integrate with WafProxy request filter
- Add 17 unit tests for bot detection
- Update configuration files with bot_detection section
- Update documentation:
  - README.md: feature highlight and config example
  - docs/security-rules.md: comprehensive section
  - docs/configuration.md: parameters and examples
  - docs/api-reference.md: BotDetector API